### PR TITLE
sort case insensitive

### DIFF
--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -8,7 +8,7 @@
 
 let s:capture = 0
 
-let g:php_namespace_sort = get(g:, 'php_namespace_sort', "'{,'}-1sort")
+let g:php_namespace_sort = get(g:, 'php_namespace_sort', "'{,'}-1sort i")
 
 let g:php_namespace_sort_after_insert = get(g:, 'php_namespace_sort_after_insert', 0)
 


### PR DESCRIPTION
Some PHP libraries use lowercase namespace ([like libphonenumber-for-php](https://github.com/giggsey/libphonenumber-for-php)) but the default vim algorithm sort case-sensitive.

Tools like "php-cs-fixer" [use case-insensitive sort](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/src/Fixer/Import/OrderedImportsFixer.php#L258-L269) which seems more logical